### PR TITLE
Update affiliation

### DIFF
--- a/SIGs/SIG-embedded/proposal.md
+++ b/SIGs/SIG-embedded/proposal.md
@@ -32,5 +32,5 @@ To ensure that all interested members of the WebAssembly community can participa
 * Dan Gohman (Fastly)
 * Stephen Berard
 * Merlinjn Sebrechts
-* Milan
+* Milan Raj (National Instruments) @rajsite
 * Qi Huang


### PR DESCRIPTION
Updated my affiliation to align with what is registered in the WebAssembly Working Group: https://www.w3.org/groups/cg/webassembly/participants/#:~:text=Milan

A helpful signal for others from my affiliated org to know I'll be participating. If there are any concerns specifying that no worries!